### PR TITLE
Fix raw HTML problem

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,3 +47,7 @@ theme = "hugo-hero-theme"
 [permalinks]
   post = "/:year/:month/:day/:slug/"
   pages = "/:filename/"
+
+# allow for raw HTML in markdown files
+[markup.goldmark.renderer]
+unsafe= true


### PR DESCRIPTION
allow for embedded HTML in markdown filesin Hugo versions 0.60.0 and higher, raw HTML is omitted in markdown files. This update enables it.